### PR TITLE
Repro bug 432905

### DIFF
--- a/articles/bugs/432905/repro.md
+++ b/articles/bugs/432905/repro.md
@@ -1,0 +1,12 @@
+---
+title: repro
+description: reproduce
+author: v-caxian
+ms.author: v-caxian
+ms.service: container-service
+---
+
+
+# Open Publishing Build Service email incorrectly reports a build has "Succeeded With Warning: Publish"
+
+[BUG 432905](https://dev.azure.com/ceapex/Engineering/_workitems/edit/432905)


### PR DESCRIPTION
Repro bug [432905](https://dev.azure.com/ceapex/Engineering/_workitems/edit/432905): Open Publishing Build Service email incorrectly reports a build has "Succeeded With Warning: Publish"